### PR TITLE
chore: dependabot groups

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,4 +5,8 @@ updates:
     schedule:
       interval: "weekly"
       time: "23:00" # UTC time
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
small improvement for dependabot introduced with https://github.com/ogcio/building-blocks-sdk/pull/25, in order to avoid a PR for each new dependency update