### PR TITLE
fix: add dynamic BuildingBlockSDKParams  clients type

### DIFF
--- a/src/client/base-client.ts
+++ b/src/client/base-client.ts
@@ -3,7 +3,7 @@ import createClient, {
   type FetchResponse,
 } from "openapi-fetch";
 import type {
-  ApiClientParams,
+  BaseApiClientParams,
   SERVICE_NAME,
   TokenFunction,
 } from "../types/index.js";
@@ -19,7 +19,7 @@ abstract class BaseClient<T extends {}> {
 
   protected client: ReturnType<typeof createClient<T>>;
 
-  constructor({ baseUrl, getTokenFn }: ApiClientParams) {
+  constructor({ baseUrl, getTokenFn }: BaseApiClientParams) {
     this.initialized = false;
     if (baseUrl) {
       this.baseUrl = baseUrl;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,25 +36,27 @@ export type SDKClientParams = {
   baseUrl?: string;
 };
 
-export type ApiClientParams = SDKClientParams & {
+export type BaseApiClientParams = SDKClientParams & {
   getTokenFn?: TokenFunction;
 };
 
 type ServiceClients = {
-  messaging: Messaging;
-  payments: Payments;
-  profile: Profile;
-  scheduler: Scheduler;
-  upload: Upload;
+  messaging: typeof Messaging;
+  payments: typeof Payments;
+  profile: typeof Profile;
+  scheduler: typeof Scheduler;
+  upload: typeof Upload;
 };
 
 export type BuildingBlocksSDK = {
-  [key in keyof ServiceClients]: ServiceClients[key];
+  [key in keyof ServiceClients]: InstanceType<ServiceClients[key]>;
 };
 
 export type BuildingBlockSDKParams = {
   services: {
-    [key in keyof ServiceClients]?: SDKClientParams;
+    [key in keyof ServiceClients]?: ConstructorParameters<
+      ServiceClients[key]
+    >[0];
   };
   getTokenFn?: TokenFunction;
 };


### PR DESCRIPTION
just a small type improvement.. I changed the type of `BuildingBlockSDKParams` so the client params are now extrapolated from the constructor of the relative client
This is useful for `Analytics SDK`, which will have other parameters other than `baseUrl` and `getTokenFn`.

Example `Analytics SDK`
```ts
import type createClient from "openapi-fetch";
import type { BaseApiClientParams } from "../../../types/index.js";
import BaseClient from "../../base-client.js";
import type { paths } from "./schema.js";

type AnalyticsParams = BaseApiClientParams & {
  newVariable?: string;
};

class Analytics extends BaseClient<paths> {
  declare client: ReturnType<typeof createClient<paths>>;

  private newVariable?: string;

  constructor({ baseUrl, getTokenFn, newVariable }: AnalyticsParams) {
    super({ baseUrl, getTokenFn });
    this.newVariable = newVariable;
  }

  getNewVariable() {
    return this.newVariable;
  }
}

export default Analytics;

```


```ts
const getBuildingBlockSDK = (
  params: BuildingBlockSDKParams,
): BuildingBlocksSDK => {
  const { services, getTokenFn } = params;
  return {
    analytics: new Analytics({
      ...services.analytics,
      getTokenFn,
    }),
    messaging: new Messaging({
      ...services.messaging,
      getTokenFn,
    }),

   ....
   
  };
};

```

<img width="567" alt="image" src="https://github.com/user-attachments/assets/c3043412-17da-498c-8508-c1dae29fa44a">

