### PR TITLE
Chore: remove export default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ogcio/building-blocks-sdk",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ogcio/building-blocks-sdk",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "license": "ISC",
       "dependencies": {
         "@ogcio/analytics-sdk": "0.0.1-beta.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ogcio/building-blocks-sdk",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ogcio/building-blocks-sdk",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "license": "ISC",
       "dependencies": {
         "@ogcio/analytics-sdk": "0.0.1-beta.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ogcio/building-blocks-sdk",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ogcio/building-blocks-sdk",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "license": "ISC",
       "dependencies": {
         "@ogcio/analytics-sdk": "0.0.1-beta.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ogcio/building-blocks-sdk",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ogcio/building-blocks-sdk",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "license": "ISC",
       "dependencies": {
         "@ogcio/analytics-sdk": "0.0.1-beta.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ogcio/building-blocks-sdk",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ogcio/building-blocks-sdk",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ogcio/building-blocks-sdk",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ogcio/building-blocks-sdk",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",

--- a/src/cli/outdated-clients-command.ts
+++ b/src/cli/outdated-clients-command.ts
@@ -7,7 +7,7 @@ import {
   OpenAPIFileFormats,
   readConfigurationFile,
 } from "../clients-configurations/read-configuration-file.js";
-import getAbsolutePath from "../utils/get-absolute-path.js";
+import { getAbsolutePath } from "../utils/get-absolute-path.js";
 import {
   CLIENTS_ROOT_FOLDER_PATH,
   OPEN_API_DEFINITION_FILE_NAME,
@@ -130,7 +130,7 @@ async function checkClients({
 
   log("All the building blocks are updated!");
 }
-const outdatedClientsCommand = new Command("clients:outdated");
+export const outdatedClientsCommand = new Command("clients:outdated");
 outdatedClientsCommand
   .description(
     "Parse a configuration file to check if the clients need to be updated",
@@ -144,5 +144,3 @@ outdatedClientsCommand
     log("Started!");
     await checkClients(options);
   });
-
-export default outdatedClientsCommand;

--- a/src/cli/update-clients-command.ts
+++ b/src/cli/update-clients-command.ts
@@ -7,7 +7,7 @@ import {
   OpenAPIFileFormats,
   readConfigurationFile,
 } from "../clients-configurations/read-configuration-file.js";
-import getAbsolutePath from "../utils/get-absolute-path.js";
+import { getAbsolutePath } from "../utils/get-absolute-path.js";
 import {
   CLIENTS_ROOT_FOLDER_PATH,
   OLD_OPEN_API_DEFINITION_FILE_NAME,
@@ -271,7 +271,7 @@ async function updateClients({
   await Promise.all(promises);
 }
 
-const updateClientsCommand = new Command("clients:update");
+export const updateClientsCommand = new Command("clients:update");
 updateClientsCommand
   .description(
     "Parse a configuration file to update the info related to the clients",
@@ -294,5 +294,3 @@ updateClientsCommand
       log("Ended!");
     },
   );
-
-export default updateClientsCommand;

--- a/src/client/base-client.ts
+++ b/src/client/base-client.ts
@@ -9,7 +9,7 @@ import type {
 } from "../types/index.js";
 import type { DataResponseValue } from "./utils/client-utils.js";
 
-abstract class BaseClient<T extends {}> {
+export abstract class BaseClient<T extends {}> {
   private baseUrl?: string;
   private initialized;
 
@@ -98,5 +98,3 @@ abstract class BaseClient<T extends {}> {
     return { error: reason } as unknown as DataResponseValue<G, O>;
   }
 }
-
-export default BaseClient;

--- a/src/client/clients/featureFlags/index.test.ts
+++ b/src/client/clients/featureFlags/index.test.ts
@@ -1,6 +1,6 @@
 import t from "tap";
 import * as td from "testdouble";
-import FeatureFlags from "./index.js";
+import { FeatureFlags } from "./index.js";
 
 let isEnabled = true;
 

--- a/src/client/clients/featureFlags/index.ts
+++ b/src/client/clients/featureFlags/index.ts
@@ -1,11 +1,11 @@
 import type createClient from "openapi-fetch";
 import type { BaseApiClientParams } from "../../../types/index.js";
 import { FEATURE_FLAGS } from "../../../types/index.js";
-import BaseClient from "../../base-client.js";
+import { BaseClient } from "../../base-client.js";
 import { DEFAULT_PROJECT_ID } from "./const.js";
 import type { components, paths } from "./schema.js";
 
-class FeatureFlags extends BaseClient<paths> {
+export class FeatureFlags extends BaseClient<paths> {
   declare client: ReturnType<typeof createClient<paths>>;
   protected serviceName = FEATURE_FLAGS;
 
@@ -68,5 +68,3 @@ class FeatureFlags extends BaseClient<paths> {
       );
   }
 }
-
-export default FeatureFlags;

--- a/src/client/clients/featureFlags/index.ts
+++ b/src/client/clients/featureFlags/index.ts
@@ -19,9 +19,13 @@ export class FeatureFlags extends BaseClient<paths> {
     this.unleashConnectionOptions = { url: baseUrl };
   }
 
-  private async importUnleashClient() {
+  private async getUnleashItems() {
     try {
-      return await import("unleash-client");
+      const { startUnleash, InMemStorageProvider } = await import(
+        "unleash-client"
+      );
+
+      return { startUnleash, InMemStorageProvider };
     } catch {
       throw new Error(
         "unleash-client is not installed or not configured correctly",
@@ -40,15 +44,15 @@ export class FeatureFlags extends BaseClient<paths> {
   // biome-ignore lint/suspicious/noExplicitAny: We cannot import the types from the unleash-client package
   async isFlagEnabled(name: string, context?: any) {
     await this.initializeConnection();
-    const unleashClient = await this.importUnleashClient();
-    const client = await unleashClient.startUnleash({
+    const unleashItems = await this.getUnleashItems();
+    const client = await unleashItems.startUnleash({
       appName: this.serviceName,
       url: `${this.unleashConnectionOptions.url}/api`,
       refreshInterval: 1000,
       customHeaders: {
         Authorization: this.unleashConnectionOptions.token ?? "",
       },
-      storageProvider: new unleashClient.InMemStorageProvider(),
+      storageProvider: new unleashItems.InMemStorageProvider(),
     });
     return client.isEnabled(name, context, () => false);
   }

--- a/src/client/clients/messaging/index.ts
+++ b/src/client/clients/messaging/index.ts
@@ -1,7 +1,7 @@
 import createError from "http-errors";
 import type createClient from "openapi-fetch";
 import { MESSAGING } from "../../../types/index.js";
-import BaseClient from "../../base-client.js";
+import { BaseClient } from "../../base-client.js";
 import {
   type PaginationParams,
   preparePaginationParams,
@@ -9,7 +9,7 @@ import {
 } from "../../utils/client-utils.js";
 import type { paths } from "./schema.js";
 
-class Messaging extends BaseClient<paths> {
+export class Messaging extends BaseClient<paths> {
   protected declare client: ReturnType<typeof createClient<paths>>;
   protected serviceName = MESSAGING;
 
@@ -679,5 +679,3 @@ class Messaging extends BaseClient<paths> {
     };
   }
 }
-
-export default Messaging;

--- a/src/client/clients/payments/index.ts
+++ b/src/client/clients/payments/index.ts
@@ -1,9 +1,9 @@
 import type createClient from "openapi-fetch";
 import { PAYMENTS } from "../../../types/index.js";
-import BaseClient from "../../base-client.js";
+import { BaseClient } from "../../base-client.js";
 import type { paths } from "./schema.js";
 
-class Payments extends BaseClient<paths> {
+export class Payments extends BaseClient<paths> {
   protected declare client: ReturnType<typeof createClient<paths>>;
   protected serviceName = PAYMENTS;
 
@@ -375,5 +375,3 @@ class Payments extends BaseClient<paths> {
       );
   }
 }
-
-export default Payments;

--- a/src/client/clients/profile/index.ts
+++ b/src/client/clients/profile/index.ts
@@ -1,9 +1,9 @@
 import type createClient from "openapi-fetch";
 import { PROFILE } from "../../../types/index.js";
-import BaseClient from "../../base-client.js";
+import { BaseClient } from "../../base-client.js";
 import type { paths } from "./schema.js";
 
-class Profile extends BaseClient<paths> {
+export class Profile extends BaseClient<paths> {
   protected declare client: ReturnType<typeof createClient<paths>>;
   protected serviceName = PROFILE;
 
@@ -178,5 +178,3 @@ class Profile extends BaseClient<paths> {
       );
   }
 }
-
-export default Profile;

--- a/src/client/clients/scheduler/index.ts
+++ b/src/client/clients/scheduler/index.ts
@@ -1,9 +1,9 @@
 import type createClient from "openapi-fetch";
 import { SCHEDULER } from "../../../types/index.js";
-import BaseClient from "../../base-client.js";
+import { BaseClient } from "../../base-client.js";
 import type { paths } from "./schema.js";
 
-class Scheduler extends BaseClient<paths> {
+export class Scheduler extends BaseClient<paths> {
   protected declare client: ReturnType<typeof createClient<paths>>;
   protected serviceName = SCHEDULER;
 
@@ -24,5 +24,3 @@ class Scheduler extends BaseClient<paths> {
       );
   }
 }
-
-export default Scheduler;

--- a/src/client/clients/upload/index.ts
+++ b/src/client/clients/upload/index.ts
@@ -1,9 +1,9 @@
 import type createClient from "openapi-fetch";
 import { UPLOAD } from "../../../types/index.js";
-import BaseClient from "../../base-client.js";
+import { BaseClient } from "../../base-client.js";
 import type { paths } from "./schema.js";
 
-class Upload extends BaseClient<paths> {
+export class Upload extends BaseClient<paths> {
   protected declare client: ReturnType<typeof createClient<paths>>;
   protected serviceName = UPLOAD;
 
@@ -147,5 +147,3 @@ class Upload extends BaseClient<paths> {
     return { error };
   }
 }
-
-export default Upload;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,20 @@
 import { Analytics } from "@ogcio/analytics-sdk";
-import FeatureFlags from "./client/clients/featureFlags/index.js";
+import { FeatureFlags } from "./client/clients/featureFlags/index.js";
 
-import Messaging from "./client/clients/messaging/index.js";
-import Payments from "./client/clients/payments/index.js";
-import Profile from "./client/clients/profile/index.js";
-import Scheduler from "./client/clients/scheduler/index.js";
-import Upload from "./client/clients/upload/index.js";
+import { Messaging } from "./client/clients/messaging/index.js";
+import { Payments } from "./client/clients/payments/index.js";
+import { Profile } from "./client/clients/profile/index.js";
+import { Scheduler } from "./client/clients/scheduler/index.js";
+import { Upload } from "./client/clients/upload/index.js";
 export type { BuildingBlocksSDK } from "./types/index.js";
 export { getM2MTokenFn } from "./client/auth/index.js";
 
 import type {
   BuildingBlockSDKParams,
   BuildingBlocksSDK,
-  TokenFunction,
 } from "./types/index.js";
 
-const getBuildingBlockSDK = (
+export const getBuildingBlockSDK = (
   params: BuildingBlockSDKParams,
 ): BuildingBlocksSDK => {
   const { services, getTokenFn } = params;
@@ -50,5 +49,3 @@ const getBuildingBlockSDK = (
     }),
   };
 };
-
-export default getBuildingBlockSDK;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,10 +1,10 @@
 import type { Analytics } from "@ogcio/analytics-sdk";
-import type FeatureFlags from "../client/clients/featureFlags/index.js";
-import type Messaging from "../client/clients/messaging/index.js";
-import type Payments from "../client/clients/payments/index.js";
-import type Profile from "../client/clients/profile/index.js";
-import type Scheduler from "../client/clients/scheduler/index.js";
-import type Upload from "../client/clients/upload/index.js";
+import type { FeatureFlags } from "../client/clients/featureFlags/index.js";
+import type { Messaging } from "../client/clients/messaging/index.js";
+import type { Payments } from "../client/clients/payments/index.js";
+import type { Profile } from "../client/clients/profile/index.js";
+import type { Scheduler } from "../client/clients/scheduler/index.js";
+import type { Upload } from "../client/clients/upload/index.js";
 
 export const ANALYTICS = "analytics" as const;
 export const MESSAGING = "messaging" as const;

--- a/src/unleash-client.d.ts
+++ b/src/unleash-client.d.ts
@@ -1,0 +1,8 @@
+declare module "unleash-client" {
+  export function startUnleash(options: UnleashConfig): Promise<Unleash>;
+  export class InMemStorageProvider<T> implements StorageProvider<T> {
+    private store;
+    set(key: string, data: T): Promise<void>;
+    get(key: string): Promise<T | undefined>;
+  }
+}

--- a/src/utils/get-absolute-path.ts
+++ b/src/utils/get-absolute-path.ts
@@ -3,8 +3,6 @@ import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-function getAbsolutePath(...relativeInputPath: string[]): string {
+export function getAbsolutePath(...relativeInputPath: string[]): string {
   return resolve(__dirname, "..", "..", ...relativeInputPath);
 }
-
-export default getAbsolutePath;


### PR DESCRIPTION
Removed export defaults to align all the exports and make us able to mock imports during testing in other services (tap mock import does not allow to have mixed default/non-default imports)