### PR TITLE
chore: add prepublishOnly script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "fix:formatting": "biome format --write",
     "check:linting": "biome lint",
     "fix:linting": "biome lint --write",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm i && npm run build && npm run test:local",
     "prepare": "husky || true"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "test": "TAP_RCFILE=tap.yml tap --reporter junit --reporter-file results.xml",
     "test:local": "TAP_RCFILE=tap.yml tap",
     "test:e2e": "cd ./e2e && bru run --env local",
-    "test:smoke:e2e": "echo \"Error: no test specified\" && exit 0",
     "test:regression:e2e": "cd ./e2e && mkdir -p test-results && bru run --env dev --output ./test-results/results.xml --format junit",
     "build": "rm -rf dist && tsc -p tsconfig.prod.json",
     "clients:update": "node --import=tsx src/cli/index.ts clients:update -c src/clients-configurations/clients-configuration.json",
@@ -17,6 +16,7 @@
     "fix:formatting": "biome format --write",
     "check:linting": "biome lint",
     "fix:linting": "biome lint --write",
+    "prepublishOnly": "npm run build",
     "prepare": "husky || true"
   },
   "dependencies": {


### PR DESCRIPTION
add `prepublishOnly` script to avoid publishing a new version of the package without having done the build