### PR TITLE
chore: add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global
+* @SamSalvatico @alewin @bozzelliandrea @matteolc


### PR DESCRIPTION
to automatically assign reviewers to open PRs, I added the `codeowners` file, same as https://github.com/ogcio/shared-node-utils/pull/13

In the future, it would also be ideal to divide/group the `codeowners` according to client/bb, but for now, since we are working in this repo only @SamSalvatico @alewin @bozzelliandrea @matteolc, I'd leave these, and gradually add others