### PR TITLE
Bump analytics sdk 0.1.0 beta 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.23",
       "license": "ISC",
       "dependencies": {
-        "@ogcio/analytics-sdk": "0.0.1-beta.4",
+        "@ogcio/analytics-sdk": "0.1.0-beta.4",
         "@sinclair/typebox": "^0.33.17",
         "commander": "^12.1.0",
         "http-errors": "^2.0.0",
@@ -1268,9 +1268,9 @@
       }
     },
     "node_modules/@ogcio/analytics-sdk": {
-      "version": "0.0.1-beta.4",
-      "resolved": "https://registry.npmjs.org/@ogcio/analytics-sdk/-/analytics-sdk-0.0.1-beta.4.tgz",
-      "integrity": "sha512-sj810sxmTwNI2+yUbLQV9FVhzjl6EbbA4M1/vvlKD8L7IxBRY4FyM4eMHuPpK9651kd3a8ILuoecehEKeVAImA==",
+      "version": "0.1.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@ogcio/analytics-sdk/-/analytics-sdk-0.1.0-beta.4.tgz",
+      "integrity": "sha512-gwx24HXQH+laGUhKitWuwOpUuJh0C25DhG9Cw/hGWs75L5pVHLuR2wCw9RvarcO7lab+YYR69gMO2ISa2DQ8gQ==",
       "license": "ISC",
       "dependencies": {
         "openapi-fetch": "^0.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ogcio/building-blocks-sdk",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ogcio/building-blocks-sdk",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "license": "ISC",
       "dependencies": {
         "@ogcio/analytics-sdk": "0.1.0-beta.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "husky || true"
   },
   "dependencies": {
-    "@ogcio/analytics-sdk": "0.0.1-beta.4",
+    "@ogcio/analytics-sdk": "0.1.0-beta.4",
     "@sinclair/typebox": "^0.33.17",
     "commander": "^12.1.0",
     "http-errors": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ogcio/building-blocks-sdk",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",


### PR DESCRIPTION
### Changelog: 

https://github.com/ogcio/analytics/blob/main/packages/analytics-sdk/CHANGELOG.md


### Breaking changes tldr:

- renamed `metadata` to `metadataOverride`
- renamed params from `snake_case` to `camelCase`. Other than that I renamed some tracking method params:

`pageView`
```ts
// before
      await sdk.analytics.track.pageView({
        event: {
          action_name: "My Page View",
        },
      })
//after
      await sdk.analytics.track.pageView({
        event: {
          title: "My Page View",
        },
      })
```

`siteSearch`
```ts
// before
      await sdk.analytics.track.siteSearch({
        event: {
          search_keyword: "My Site Search",
          search_count: 1,
          search_category: "My Search Category",
        },
      })
// after
      await sdk.analytics.track.siteSearch({
        event: {
          query: "My Site Search",
          count: 1,
          category: "My Search Category",
        },
      })
```

`contentImpression` and `contentInteraction`

```ts

// before
      await sdk.analytics.generate.contentInteraction({
        event: {
          content_interaction: "impression",
          content_name: "My Content Name",
          content_piece: "My Content Piece",
          content_target: "My Content Target",
        },
      })
// after
      await sdk.analytics.generate.contentInteraction({
        event: {
          interaction: "impression",
          name: "My Content Name",
          piece: "My Content Piece",
          target: "My Content Target",
        },
      })
```