### PR TITLE
chore(docs): add analytics to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ At the present time available building blocks are:
 - upload
 - profile
 - scheduler
+- analytics
 
 ### Authentication
 


### PR DESCRIPTION
Add a line in readme to highlight that analytics is also available as one of the services.