### PR TITLE
chore: add gitleaks pre-commit hook

### DIFF
--- a/.azure/pipeline.yaml
+++ b/.azure/pipeline.yaml
@@ -35,22 +35,23 @@ stages:
       vmImage: "ubuntu-latest"
     jobs:
       - template: security/gitleaks.yml@pipeline-templates
-      - job:
-        displayName: Checkmarx KICS
-        pool:
-          vmImage: "ubuntu-latest"
-        container: checkmarx/kics:debian
-        steps:
-          - script: /app/bin/kics scan -p ${PWD} -o ${PWD} --report-formats "json,JUnit" --output-name kics-result --ci --fail-on 'critical,high' --config ./kics-config.json
-            displayName: KICS Scan
-          - script: cat kics-result.json
-            condition: succeededOrFailed()
-            displayName: KICS Results
-          - task: PublishTestResults@2
-            condition: succeededOrFailed()
-            inputs:
-              testResultsFormat: "JUnit"
-              testResultsFiles: "$(System.DefaultWorkingDirectory)/junit-kics-result.xml"
+      # TODO: Uncomment when KICS is ready ( Timeout processing the results of the query: openAPI array_without_maximum_number_items error="context deadline exceeded )
+      # - job:
+      #   displayName: Checkmarx KICS
+      #   pool:
+      #     vmImage: "ubuntu-latest"
+      #   container: checkmarx/kics:debian
+      #   steps:
+      #     - script: /app/bin/kics scan -p ${PWD} -o ${PWD} --report-formats "json,JUnit" --output-name kics-result --ci --fail-on 'critical,high' --config ./kics-config.json
+      #       displayName: KICS Scan
+      #     - script: cat kics-result.json
+      #       condition: succeededOrFailed()
+      #       displayName: KICS Results
+      #     - task: PublishTestResults@2
+      #       condition: succeededOrFailed()
+      #       inputs:
+      #         testResultsFormat: "JUnit"
+      #         testResultsFiles: "$(System.DefaultWorkingDirectory)/junit-kics-result.xml"
 
   - stage: lintingAndFormatting
     displayName: Linting and Formatting Checks

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 results.xml
 coverage/
+.DS_Store

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,3 @@
+# Ignore OpenAPI examples values
+/src/src/client/clients/featureFlags/open-api-definition.json:generic-api-key:9024
+/src/src/client/clients/featureFlags/schema.ts:generic-api-key:9202

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,6 @@
 pnpm check:formatting
 pnpm check:linting
+
+GITLEAKS_CONTAINER="gitleaks-precommit"
+docker rm -f $GITLEAKS_CONTAINER 2>/dev/null || true
+docker run --name $GITLEAKS_CONTAINER -v $(pwd):/src ghcr.io/gitleaks/gitleaks:v8.19.3 protect --source="/src" --verbose --redact --staged

--- a/kics-config.json
+++ b/kics-config.json
@@ -1,6 +1,6 @@
 {
   "log-file": true,
-  "type": "Common,Dockerfile,OpenAPI",
+  "type": "CICD,Dockerfile,OpenAPI",
   "exclude-paths": ["dist", "node_modules", "coverage"],
   "output-path": "results",
   "exclude-queries": "",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@biomejs/biome": "1.9.4",
     "@commitlint/config-conventional": "^19.5.0",
     "@types/http-errors": "^2.0.4",
+    "@types/node": "^20.11.28",
     "@vitest/coverage-istanbul": "^2.1.4",
     "commitlint": "^19.5.0",
     "husky": "^9.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,12 +51,15 @@ importers:
       '@types/http-errors':
         specifier: ^2.0.4
         version: 2.0.4
+      '@types/node':
+        specifier: ^20.11.28
+        version: 20.17.7
       '@vitest/coverage-istanbul':
         specifier: ^2.1.4
-        version: 2.1.5(vitest@2.1.5(@types/node@22.9.0))
+        version: 2.1.5(vitest@2.1.5(@types/node@20.17.7))
       commitlint:
         specifier: ^19.5.0
-        version: 19.5.0(@types/node@22.9.0)(typescript@5.6.3)
+        version: 19.5.0(@types/node@20.17.7)(typescript@5.6.3)
       husky:
         specifier: ^9.1.6
         version: 9.1.6
@@ -68,7 +71,7 @@ importers:
         version: 5.6.3
       vitest:
         specifier: ^2.1.4
-        version: 2.1.5(@types/node@22.9.0)
+        version: 2.1.5(@types/node@20.17.7)
 
 packages:
 
@@ -710,8 +713,8 @@ packages:
   '@types/http-errors@2.0.4':
     resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
 
-  '@types/node@22.9.0':
-    resolution: {integrity: sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==}
+  '@types/node@20.17.7':
+    resolution: {integrity: sha512-sZXXnpBFMKbao30dUAvzKbdwA2JM1fwUtVEq/kxKuPI5mMwZiRElCpTXb0Biq/LMEVpXDZL5G5V0RPnxKeyaYg==}
 
   '@vitest/coverage-istanbul@2.1.5':
     resolution: {integrity: sha512-jJsS5jeHncmSvzMNE03F1pk8F9etmjzGmGyQnGMkdHdVek/bxK/3vo8Qr3e9XmVuDM3UZKOy1ObeQHgC2OxvHg==}
@@ -1889,11 +1892,11 @@ snapshots:
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
-  '@commitlint/cli@19.5.0(@types/node@22.9.0)(typescript@5.6.3)':
+  '@commitlint/cli@19.5.0(@types/node@20.17.7)(typescript@5.6.3)':
     dependencies:
       '@commitlint/format': 19.5.0
       '@commitlint/lint': 19.5.0
-      '@commitlint/load': 19.5.0(@types/node@22.9.0)(typescript@5.6.3)
+      '@commitlint/load': 19.5.0(@types/node@20.17.7)(typescript@5.6.3)
       '@commitlint/read': 19.5.0
       '@commitlint/types': 19.5.0
       tinyexec: 0.3.1
@@ -1940,7 +1943,7 @@ snapshots:
       '@commitlint/rules': 19.5.0
       '@commitlint/types': 19.5.0
 
-  '@commitlint/load@19.5.0(@types/node@22.9.0)(typescript@5.6.3)':
+  '@commitlint/load@19.5.0(@types/node@20.17.7)(typescript@5.6.3)':
     dependencies:
       '@commitlint/config-validator': 19.5.0
       '@commitlint/execute-rule': 19.5.0
@@ -1948,7 +1951,7 @@ snapshots:
       '@commitlint/types': 19.5.0
       chalk: 5.3.0
       cosmiconfig: 9.0.0(typescript@5.6.3)
-      cosmiconfig-typescript-loader: 5.1.0(@types/node@22.9.0)(cosmiconfig@9.0.0(typescript@5.6.3))(typescript@5.6.3)
+      cosmiconfig-typescript-loader: 5.1.0(@types/node@20.17.7)(cosmiconfig@9.0.0(typescript@5.6.3))(typescript@5.6.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -2294,17 +2297,17 @@ snapshots:
 
   '@types/conventional-commits-parser@5.0.0':
     dependencies:
-      '@types/node': 22.9.0
+      '@types/node': 20.17.7
 
   '@types/estree@1.0.6': {}
 
   '@types/http-errors@2.0.4': {}
 
-  '@types/node@22.9.0':
+  '@types/node@20.17.7':
     dependencies:
       undici-types: 6.19.8
 
-  '@vitest/coverage-istanbul@2.1.5(vitest@2.1.5(@types/node@22.9.0))':
+  '@vitest/coverage-istanbul@2.1.5(vitest@2.1.5(@types/node@20.17.7))':
     dependencies:
       '@istanbuljs/schema': 0.1.3
       debug: 4.3.7(supports-color@9.4.0)
@@ -2316,7 +2319,7 @@ snapshots:
       magicast: 0.3.5
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.5(@types/node@22.9.0)
+      vitest: 2.1.5(@types/node@20.17.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -2327,13 +2330,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.5(vite@5.4.11(@types/node@22.9.0))':
+  '@vitest/mocker@2.1.5(vite@5.4.11(@types/node@20.17.7))':
     dependencies:
       '@vitest/spy': 2.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.12
     optionalDependencies:
-      vite: 5.4.11(@types/node@22.9.0)
+      vite: 5.4.11(@types/node@20.17.7)
 
   '@vitest/pretty-format@2.1.5':
     dependencies:
@@ -2478,9 +2481,9 @@ snapshots:
 
   commander@12.1.0: {}
 
-  commitlint@19.5.0(@types/node@22.9.0)(typescript@5.6.3):
+  commitlint@19.5.0(@types/node@20.17.7)(typescript@5.6.3):
     dependencies:
-      '@commitlint/cli': 19.5.0(@types/node@22.9.0)(typescript@5.6.3)
+      '@commitlint/cli': 19.5.0(@types/node@20.17.7)(typescript@5.6.3)
       '@commitlint/types': 19.5.0
     transitivePeerDependencies:
       - '@types/node'
@@ -2508,9 +2511,9 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cosmiconfig-typescript-loader@5.1.0(@types/node@22.9.0)(cosmiconfig@9.0.0(typescript@5.6.3))(typescript@5.6.3):
+  cosmiconfig-typescript-loader@5.1.0(@types/node@20.17.7)(cosmiconfig@9.0.0(typescript@5.6.3))(typescript@5.6.3):
     dependencies:
-      '@types/node': 22.9.0
+      '@types/node': 20.17.7
       cosmiconfig: 9.0.0(typescript@5.6.3)
       jiti: 1.21.6
       typescript: 5.6.3
@@ -3231,13 +3234,13 @@ snapshots:
 
   uri-js-replace@1.0.1: {}
 
-  vite-node@2.1.5(@types/node@22.9.0):
+  vite-node@2.1.5(@types/node@20.17.7):
     dependencies:
       cac: 6.7.14
       debug: 4.3.7(supports-color@9.4.0)
       es-module-lexer: 1.5.4
       pathe: 1.1.2
-      vite: 5.4.11(@types/node@22.9.0)
+      vite: 5.4.11(@types/node@20.17.7)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -3249,19 +3252,19 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.11(@types/node@22.9.0):
+  vite@5.4.11(@types/node@20.17.7):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.49
       rollup: 4.26.0
     optionalDependencies:
-      '@types/node': 22.9.0
+      '@types/node': 20.17.7
       fsevents: 2.3.3
 
-  vitest@2.1.5(@types/node@22.9.0):
+  vitest@2.1.5(@types/node@20.17.7):
     dependencies:
       '@vitest/expect': 2.1.5
-      '@vitest/mocker': 2.1.5(vite@5.4.11(@types/node@22.9.0))
+      '@vitest/mocker': 2.1.5(vite@5.4.11(@types/node@20.17.7))
       '@vitest/pretty-format': 2.1.5
       '@vitest/runner': 2.1.5
       '@vitest/snapshot': 2.1.5
@@ -3277,11 +3280,11 @@ snapshots:
       tinyexec: 0.3.1
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
-      vite: 5.4.11(@types/node@22.9.0)
-      vite-node: 2.1.5(@types/node@22.9.0)
+      vite: 5.4.11(@types/node@20.17.7)
+      vite-node: 2.1.5(@types/node@20.17.7)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.9.0
+      '@types/node': 20.17.7
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
- add husky gitleaks pre-commit
- commented kics scan

<img width="938" alt="image" src="https://github.com/user-attachments/assets/70f2cec2-4497-46fd-8631-6f1363f8eb62">


i temporary commented the kics scan because of an error, and I realised that there is an openapi definition file and schemas.ts that are very large, probabily not essential, what do you think? @matteolc  the `schema` is present also in the `build/dist`

<img width="642" alt="image" src="https://github.com/user-attachments/assets/8cfaf7d0-9a31-4b9d-b257-53c342512f75">
