### PR TITLE
chore: bump 0.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ogcio/building-blocks-sdk",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",


### PR DESCRIPTION
missing bump during https://github.com/ogcio/building-blocks-sdk/pull/86