### PR TITLE
chore: release please bump-patch-for-minor-pre-major true

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,7 +19,7 @@
       "component": "@ogcio/building-blocks-sdk",
       "release-type": "node",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false
+      "bump-patch-for-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
Since `bb-sdk` is still not stable we'll increase the minor for breaking changes, and patch for the minor changes

fixing this `release-please` pr:  https://github.com/ogcio/building-blocks-sdk/pull/94