### PR TITLE
feat: add expiry time and check on request middleware

### DIFF
--- a/src/__tests__/client/utils/client-utils.test.ts
+++ b/src/__tests__/client/utils/client-utils.test.ts
@@ -3,6 +3,8 @@ import {
   type PaginationParams,
   formatError,
   formatResponse,
+  getNumberValueFromObject,
+  parseJwtToken,
   preparePaginationParams,
   toStringOrUndefined,
 } from "./../../../client/utils/client-utils.js";
@@ -156,5 +158,69 @@ describe("formatError", () => {
     expect(result).toEqual({
       error: errorMessage,
     });
+  });
+});
+
+describe(parseJwtToken.name, () => {
+  it("should throw on empty string parameter", () => {
+    expect(() => parseJwtToken("")).toThrow("invalid jwt format");
+  });
+
+  it("should throw on illegal jwt characters parameter", () => {
+    expect(() => parseJwtToken("all.the.parts!")).toThrow("invalid jwt format");
+  });
+
+  it("should throw on too long jwt format parameter", () => {
+    expect(() => parseJwtToken("too.many.parts.here")).toThrow(
+      "invalid jwt format",
+    );
+  });
+
+  it("should throw on too short jwt format parameter", () => {
+    expect(() => parseJwtToken("parts.missing")).toThrow("invalid jwt format");
+  });
+
+  it("should throw if payload is invalid json", () => {
+    expect(() =>
+      parseJwtToken(
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.invalidJsonPayload.dXNlcnNlY3JldA",
+      ),
+    ).toThrow("invalid jwt format");
+  });
+});
+
+describe(getNumberValueFromObject.name, () => {
+  it("should return correct with numeric value type", () => {
+    const expected = 123;
+    const actual = getNumberValueFromObject({ exp: 123 }, "exp");
+
+    expect(actual).toBeTypeOf("number");
+    expect(actual).toBe(expected);
+  });
+
+  it("should return correct with string value type that represent a valid number", () => {
+    const expected = 123;
+    const actual = getNumberValueFromObject({ exp: "123" }, "exp");
+
+    expect(actual).toBeTypeOf("number");
+    expect(actual).toBe(expected);
+  });
+
+  it("should throw if value string isn't parseable as number", () => {
+    expect(() => getNumberValueFromObject({ exp: "12a3" }, "exp")).toThrow(
+      "failed to cast 12a3 to number",
+    );
+  });
+
+  it("should throw if value type is null", () => {
+    expect(() => getNumberValueFromObject({ exp: null }, "exp")).toThrow(
+      "failed to cast null to number",
+    );
+  });
+
+  it("should throw if value type is undefined", () => {
+    expect(() => getNumberValueFromObject({ expo: 123 }, "exp")).toThrow(
+      "failed to cast undefined to number",
+    );
   });
 });

--- a/src/client/utils/client-utils.ts
+++ b/src/client/utils/client-utils.ts
@@ -99,3 +99,42 @@ export function formatError<G, O>(
   }
   return { error: reason } as unknown as DataResponseValue<G, O>;
 }
+
+export function parseJwtToken(token: string): {
+  header: Record<string, unknown>;
+  payload: Record<string, unknown>;
+} {
+  const parts = token.split(".");
+  if (!parts || parts.length !== 3) {
+    throw "invalid jwt format";
+  }
+
+  const [headerPart, payloadPart] = parts;
+  try {
+    return {
+      header: JSON.parse(Buffer.from(headerPart, "base64").toString()),
+      payload: JSON.parse(Buffer.from(payloadPart, "base64").toString()),
+    };
+  } catch (_err) {
+    throw "invalid jwt format";
+  }
+}
+
+export function getNumberValueFromObject(
+  object: Record<string, unknown>,
+  key: string,
+): number {
+  const value = object[key];
+  if (value === null) {
+    throw new Error("failed to cast null to number");
+  }
+
+  if (value === undefined) {
+    throw new Error("failed to cast undefined to number");
+  }
+
+  if (Number.isNaN(Number(value))) {
+    throw new Error(`failed to cast ${value} to number`);
+  }
+  return Number(value);
+}


### PR DESCRIPTION
Instead of forcing implementers to re instantiate an sdk instance whenever a token would expire, we would call the supplied getTokenFn, to get a new one instead.