### PR TITLE
ci: add npm credentials from aws secrets manager

### DIFF
--- a/.azure/pipeline.yaml
+++ b/.azure/pipeline.yaml
@@ -18,7 +18,8 @@ resources:
 
 variables:
   secretsManagerAwsConnection: "PROD-LifeEvents"
-  githubSecret: "github-token"
+  githubSecret: "shared-secrets/github-token"
+  npmjsSecret: "shared-secrets/npmjs-token"
   awsRegion: "eu-west-1"
 
 stages:
@@ -148,8 +149,8 @@ stages:
     pool:
       vmImage: "ubuntu-latest"
     jobs:
-      - job: githubCredentials
-        displayName: GitHub credentials
+      - job: retrievePublishCredentials
+        displayName: Retrieve GitHub and NPM credentials
         steps:
           - checkout: none
           - task: AWSShellScript@1
@@ -162,6 +163,16 @@ stages:
               inlineScript: |
                 export GITHUB_TOKEN=$(aws secretsmanager get-secret-value --secret-id ${{ variables.githubSecret }} | jq --raw-output '.SecretString' | jq -r .GITHUB_TOKEN)
                 echo "##vso[task.setvariable variable=githubTokenADO;issecret=true;isoutput=true;]$GITHUB_TOKEN"
+          - task: AWSShellScript@1
+            name: setNPMjsToken
+            displayName: Retrieve NPM credentials
+            inputs:
+              awsCredentials: ${{ variables.secretsManagerAwsConnection }}
+              regionName: ${{ variables.awsRegion }}
+              scriptType: "inline"
+              inlineScript: |
+                export TOKEN=$(aws secretsmanager get-secret-value --secret-id ${{ variables.npmjsSecret }} | jq --raw-output '.SecretString' | jq -r .TOKEN)
+                echo "##vso[task.setvariable variable=npmjsTokenADO;issecret=true;isoutput=true;]$TOKEN"
 
   - stage: release
     displayName: Release Management
@@ -169,16 +180,17 @@ stages:
     jobs:
       - job: HandleRelease
         variables:
-          - group: building-blocks-sdk
           - name: githubTokenADO
-            value: $[stageDependencies.retrieveCredentials.githubCredentials.outputs['setGithubToken.githubTokenADO']]
+            value: $[stageDependencies.retrieveCredentials.retrievePublishCredentials.outputs['setGithubToken.githubTokenADO']]
+          - name: npmjsTokenADO
+            value: $[stageDependencies.retrieveCredentials.retrievePublishCredentials.outputs['setNPMjsToken.npmjsTokenADO']]
         displayName: Handle Release Process
         pool:
           vmImage: "ubuntu-latest"
         steps:
           - template: release/release-please.yml@pipeline-templates
             parameters:
-              npmToken: $(NPM_TOKEN)
+              npmToken: $(npmjsTokenADO)
               githubToken: $(githubTokenADO)
               repoUrl: "https://github.com/ogcio/building-blocks-sdk"
               packageName: "@ogcio/building-blocks-sdk"


### PR DESCRIPTION
in this way we no longer use my token from the azure devops library, but a unique shared token for all the ogcio packages of npm