### PR TITLE
feat: update analytics sdk to beta10

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "husky || true"
   },
   "dependencies": {
-    "@ogcio/analytics-sdk": "0.1.0-beta.8",
+    "@ogcio/analytics-sdk": "0.1.0-beta.10",
     "@sinclair/typebox": "^0.34.11",
     "commander": "^13.0.0",
     "http-errors": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 2.5.5
         version: 2.5.5
       '@ogcio/analytics-sdk':
-        specifier: 0.1.0-beta.8
-        version: 0.1.0-beta.8
+        specifier: 0.1.0-beta.10
+        version: 0.1.0-beta.10
       '@sinclair/typebox':
         specifier: ^0.34.11
         version: 0.34.13
@@ -589,8 +589,8 @@ packages:
     resolution: {integrity: sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  '@ogcio/analytics-sdk@0.1.0-beta.8':
-    resolution: {integrity: sha512-KhTcFxDY9R0SH4LJiPLeZneNKyizxwuyt3FsNrJ99AD5om96HhZHVVBtTkjNa2lBhZV2xFnn6q+X0HyoVEi8wg==}
+  '@ogcio/analytics-sdk@0.1.0-beta.10':
+    resolution: {integrity: sha512-WYkJ8IwsGzPJNfxzMYgwrUH08DDiT3WxowhGABuS00qGiEsIaSq9W/wMDka7fLB9lZA3CfM3AB8Xk4wxgsy9Sg==}
     engines: {node: '>=17.0.0'}
 
   '@pkgjs/parseargs@0.11.0':
@@ -2211,7 +2211,7 @@ snapshots:
     dependencies:
       semver: 7.6.3
 
-  '@ogcio/analytics-sdk@0.1.0-beta.8':
+  '@ogcio/analytics-sdk@0.1.0-beta.10':
     dependencies:
       openapi-fetch: 0.13.4
       openapi-typescript-helpers: 0.0.15


### PR DESCRIPTION

## Features
- update base client with logger support and jwt expiration

## Breaking Changes
- Removed auth from tracking methods, now whether used in the backend or the frontend, the analytics module will not need to define the `getTokenFn`, as the tracking APIs are now public. All the methods under `administration` needs auth
- Removed deprecated constructor parameters (`trackingContext`, `trackingMetadata`), you should now use `setTrackingContext` and `setTrackingMetadata`
- Removed deprecated parameters (`userId`, `customDimensions`) from the `initClientTracker` method. Please use `setTrackingContext` instead.

## Fixes:
- fix `setTrackingContext` race condition [24326](https://dev.azure.com/OGCIO-Digital-Services/Digital%20Services%20Programme/_workitems/edit/24326) cc: @G100g 

