### PR TITLE
fix: remove unused silent and fatal methods from logger interface

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -94,13 +94,11 @@ interface LogFn {
 }
 
 export type Logger = {
-  fatal: LogFn;
   error: LogFn;
   warn: LogFn;
   info: LogFn;
   debug: LogFn;
   trace: LogFn;
-  silent: LogFn;
 };
 
 interface BuildingBlockSDKParams {


### PR DESCRIPTION
this change enables us to use `console` as a logger removing from the type `fatal` and `silent` methods, that are specifically related to `pinojs`

It doesn’t introduce any breaking changes since `fatal` and `silent` were not used internally, and we can continue to pass `pinojs` as logger

